### PR TITLE
Leverage BigNumber to avoid rounding errors

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2,7 +2,7 @@
 const axios = require('axios');
 const retry = require('async-retry');
 const _ = require('lodash');
-const { ethers } = require('ethers');
+const { ethers, BigNumber} = require('ethers');
 // local
 const { currencies } = require('./currencies.js');
 
@@ -15,11 +15,7 @@ function _reducer(previous, current) {
   const currency = currencies[current.token.toLowerCase()];
 
   if (currency !== undefined) {
-    const result =
-      previous +
-      Number(ethers.utils.formatUnits(current.amount, currency.decimals));
-
-    return result;
+    return previous.add(current.amount);
   } else {
     return previous;
   }
@@ -36,13 +32,13 @@ function getSeaportSalePrice(decodedLogData, contractAddress) {
 
   // if nfts are on the offer side, then consideration is the total price, otherwise the offer is the total price
   if (offerSideNfts) {
-    const totalConsiderationAmount = consideration.reduce(_reducer, 0);
-
-    return totalConsiderationAmount;
+    const totalConsiderationAmount = consideration.reduce(_reducer, BigNumber.from(0));
+    const currency = currencies[consideration[0].token.toLowerCase()]; //assumes all consideration tokens are the same
+    return ethers.utils.formatUnits(totalConsiderationAmount, currency.decimals);
   } else {
-    const totalOfferAmount = offer.reduce(_reducer, 0);
-
-    return totalOfferAmount;
+    const totalOfferAmount = offer.reduce(_reducer, BigNumber.from(0));
+    const currency = currencies[offer[0].token.toLowerCase()]; //assumes all offer tokens are the same
+    return ethers.utils.formatUnits(totalOfferAmount, currency.decimals);
   }
 }
 


### PR DESCRIPTION
Use BigNumber from ethers when reducing in order to avoid rounding errors.

This solution assumes that all amounts in the consideration / offer array are of the same currency.