### PR TITLE
Fix double counting for reserved sales on Seaport

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 // external
-const { ethers, BigNumber} = require('ethers');
+const { ethers } = require('ethers');
 // local
 const { currencies } = require('./currencies.js');
 
@@ -23,17 +23,24 @@ function getSeaportSalePrice(decodedLogData, contractAddress) {
     (item) =>
       item.token.toLowerCase() === contractAddress.toLowerCase()
   );
+  const considerationSideNfts = consideration.some(
+    (item) =>
+      item.token.toLowerCase() === contractAddress.toLowerCase()
+  );
 
   // if nfts are on the offer side, then consideration is the total price, otherwise the offer is the total price
   if (offerSideNfts) {
     const totalConsiderationAmount = consideration.reduce(_reducer, 0);
 
     return totalConsiderationAmount;
-  } else {
+  }
+  if (considerationSideNfts) {
     const totalOfferAmount = offer.reduce(_reducer, 0);
 
     return totalOfferAmount;
   }
+
+  return 0;
 }
 
 module.exports = {


### PR DESCRIPTION
This PR attempts to fix 18 - https://github.com/dsgriffin/nft-sales-twitter-bot/issues/18

For reserved sales on Seaport the code is double counting. The tx receipt logs contain two `OrderFulfilled` Transfer Event types, along the lines of the following:

```json
[
{
  "orderHash": "0x5affc5916e656138b1882ad44b3499e4911cd9c5baee80f62b82ee9d4496d6b9",
  "offerer": "0x4181DEeED2eC6670F90bE959573c960DeCf6c899",
  "zone": "0x004C00500000aD104D7DBd00e3ae0A5C00560C00",
  "recipient": "0x99e875aC4053Aa1773A10E1c516b9Dd0FaBCf67A",
  "offer": {
    "itemType": 2,
    "token": "0xCaF67CBd80Fa1Cc4C5dE7eDc77842E968144Aee9",
    "identifier": {
      "type": "BigNumber",
      "hex": "0x08"
    },
    "amount": {
      "type": "BigNumber",
      "hex": "0x01"
    }
  },
  "consideration": {
    "itemType": 0,
    "token": "0x0000000000000000000000000000000000000000", // ETH
    "identifier": {
      "type": "BigNumber",
      "hex": "0x00"
    },
    "amount": {
      "type": "BigNumber",
      "hex": "0x0c189dc59f204000"
    },
    "recipient": "0x4181DEeED2eC6670F90bE959573c960DeCf6c899"
  }
},

{
  "orderHash": "0x36ede0a48e5bd70c835264e97139645b3191659525989b0245f2fc9fd56de166",
  "offerer": "0x99e875aC4053Aa1773A10E1c516b9Dd0FaBCf67A",
  "zone": "0x0000000000000000000000000000000000000000",
  "recipient": "0x99e875aC4053Aa1773A10E1c516b9Dd0FaBCf67A",
  "offer": {
    "itemType": 0,
    "token": "0x0000000000000000000000000000000000000000",
    "identifier": {
      "type": "BigNumber",
      "hex": "0x00"
    },
    "amount": {
      "type": "BigNumber",
      "hex": "0x0c282d5bd73e0000"
    }
  },
  "consideration": {}
}
]
```

The code currently assumes that if there **is a token** in the offerSide, therefore count the amount on the consideration side, if not, do the opposite. In the second log, there is **no token** in the offer side, therefore we assume there's a token in the consideration side and count the amount in the offer; however, there is no token in the consideration so should we really be counting the offer?

This PR returns 0 if there is no token in the log.

I have not researched the Seaport contract in depth so I don't know what the expected behaviour should be but I notice that this seems to resolve the double-counting as we'd skip the counting of the 2nd tx log.

